### PR TITLE
Fix tests and require Node.js 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .nyc_output
+.test-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - '10'
+  - '8'
   - '6'
   - '4'
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '10'
   - '8'
   - '6'
-  - '4'
 before_install:
   - 'npm i -g npm@latest'
 after_script:

--- a/index.js
+++ b/index.js
@@ -22,16 +22,11 @@ function wrap(opts) {
 	}
 
 	let transformFn = opts.transform;
-	const factory = opts.factory;
-	const cacheDir = opts.cacheDir;
+	const {factory, cacheDir, shouldTransform, disableCache, hashData, onHash} = opts;
 	const cacheDirCreated = opts.createCacheDir === false;
 	let created = transformFn && cacheDirCreated;
 	const ext = opts.ext || '';
 	const salt = opts.salt || '';
-	const shouldTransform = opts.shouldTransform;
-	const disableCache = opts.disableCache;
-	const hashData = opts.hashData;
-	const onHash = opts.onHash;
 	const encoding = opts.encoding === 'buffer' ? undefined : opts.encoding || 'utf8';
 
 	function transform(input, metadata, hash) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && nyc ava"
@@ -34,13 +34,13 @@
     "write-file-atomic": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^0.19.1",
-    "coveralls": "^2.11.6",
-    "nyc": "^10.3.2",
-    "proxyquire": "^1.7.3",
+    "ava": "^0.25.0",
+    "coveralls": "^3.0.1",
+    "nyc": "^12.0.2",
+    "proxyquire": "^2.0.1",
     "rimraf": "^2.6.2",
-    "sinon": "^2.2.0",
-    "xo": "^0.18.2"
+    "sinon": "^5.1.0",
+    "xo": "^0.21.1"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "ava": "^0.19.1",
     "coveralls": "^2.11.6",
-    "mock-fs": "^3.5.0",
     "nyc": "^10.3.2",
     "proxyquire": "^1.7.3",
+    "rimraf": "^2.6.2",
     "sinon": "^2.2.0",
     "xo": "^0.18.2"
   },


### PR DESCRIPTION
Fix testing by removing mock-fs.  Use a separate cache directory per test stored on the real filesystem.  First commit fixes `npm test`.  The second commit updates all development dependencies and requires node.js 6.  The only code change is use of object destructuring.

Fixes #9